### PR TITLE
Variable Initialization Check

### DIFF
--- a/IPNListener.php
+++ b/IPNListener.php
@@ -312,21 +312,20 @@ class IPNListener
 			}
 
 			$myPost = array();
-			foreach ($raw_post_array as $keyval) {
-				$keyval = explode ('=', $keyval);
-				if (count($keyval) == 2) {
-					$myPost[$keyval[0]] = urldecode($keyval[1]);
-				}
-			}
+            if (isset($raw_post_array)) {
+                foreach ($raw_post_array as $keyval) {
+                    $keyval = explode('=', $keyval);
+                    if (count($keyval) == 2) {
+                        $myPost[$keyval[0]] = urldecode($keyval[1]);
+                    }
+                }
+            }
 
 			// read the post from PayPal system and add 'cmd'
 			$req = 'cmd=_notify-validate';
-			if(function_exists('get_magic_quotes_gpc')) {
-				$get_magic_quotes_exists = true;
-			}
 
 			foreach ($myPost as $key => $value) {
-				if($get_magic_quotes_exists == true && get_magic_quotes_gpc() == 1) {
+				if (function_exists('get_magic_quotes_gpc') && get_magic_quotes_gpc() == 1) {
 					$value = urlencode(stripslashes($value));
 				} else {
 					$value = urlencode($value);


### PR DESCRIPTION
- Added check to make sure $raw_post_array is set before attempting to
iterate through it.
- $get_magic_quotes_exists variable was redundant and only used in one
place. Moved function_exists('get_magic_quotes_gpc') check to the only
place the $get_magic_quotes_exists variable was being used.