### PR TITLE
Add support for composer autoloader

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,9 @@ below. For a more thoroughly documented example, take a look at the
 
     <?php
 
-    include('/path/to/IPNListener.php');
+    require_once('vendor/autoload.php');
 
-    $listener = new IPNListener();
+    $listener = new \WadeShuler\PhpPaypalIpn\IpnListener();
     $listener->use_sandbox = true;
 
     if ($verified = $listener->processIpn())

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "homepage": "https://github.com/WadeShuler/PHP-PayPal-IPN",
     "keywords": ["paypal", "ipn", "php"],
     "license": "GPL-2.0+",
-    "version": "2.2.0",
+    "version": "2.3.0",
     "authors": [
         {
             "name": "Wade Shuler",
@@ -23,5 +23,10 @@
     },
     "require": {
         "php": ">=5.3.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "WadeShuler\\PhpPaypalIpn\\": "src/"
+        }
     }
 }

--- a/src/IpnListener.php
+++ b/src/IpnListener.php
@@ -20,6 +20,8 @@
 
 namespace WadeShuler\PhpPaypalIpn;
 
+use Exception;
+
 class IpnListener
 {
 

--- a/src/IpnListener.php
+++ b/src/IpnListener.php
@@ -18,7 +18,9 @@
  *  @version    2.2.0
  */
 
-class IPNListener
+namespace WadeShuler\PhpPaypalIpn;
+
+class IpnListener
 {
 
     /**


### PR DESCRIPTION
I've moved the class into a namespace (WadeShuler\PhpPaypalIpn) so it can be autoloaded. The updated readme shows how to use it this new way:

```php
<?php
require_once('vendor/autoload.php');
$listener = new \WadeShuler\PhpPaypalIpn\IpnListener();
```

This should make it nicer to use when installing via composer.