### PR TITLE
Fix SSL validation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "homepage": "https://github.com/WadeShuler/PHP-PayPal-IPN",
     "keywords": ["paypal", "ipn", "php"],
     "license": "GPL-2.0+",
-    "version": "2.3.0",
+    "version": "2.4.0",
     "authors": [
         {
             "name": "Wade Shuler",

--- a/src/IpnListener.php
+++ b/src/IpnListener.php
@@ -58,15 +58,15 @@ class IpnListener
     public $timeout = 30;
 
     /**
-     * If true, enabled SSL certification validation when using cURL
+     * If true, enable SSL certification validation when using cURL
      *
      * @var boolean
      */
     public $verify_ssl = true;
 
-	private $_errors = array();
+    private $_errors = array();
     private $post_data;
-	private $rawPostData;				// raw data from php://input
+    private $rawPostData;				// raw data from php://input
     private $post_uri = '';
     private $response_status = '';
     private $response = '';

--- a/src/IpnListener.php
+++ b/src/IpnListener.php
@@ -42,15 +42,6 @@ class IpnListener
     public $follow_location = false;
 
     /**
-     *  If true, an SSL secure connection (port 443) is used for the post back
-     *  as recommended by PayPal. If false, a standard HTTP (port 80) connection
-     *  is used. Default true.
-     *
-     *  @var boolean
-     */
-    public $use_ssl = true;
-
-    /**
      *  If true, the paypal sandbox URI www.sandbox.paypal.com is used for the
      *  post back. If false, the live URI www.paypal.com is used. Default false.
      *
@@ -91,13 +82,8 @@ class IpnListener
     protected function curlPost($encoded_data)
 	{
 
-        if ($this->use_ssl) {
-            $uri = 'https://'.$this->getPaypalHost().'/cgi-bin/webscr';
-            $this->post_uri = $uri;
-        } else {
-            $uri = 'http://'.$this->getPaypalHost().'/cgi-bin/webscr';
-            $this->post_uri = $uri;
-        }
+        $uri = 'https://'.$this->getPaypalHost().'/cgi-bin/webscr';
+        $this->post_uri = $uri;
 
         $ch = curl_init();
 
@@ -139,15 +125,9 @@ class IpnListener
     protected function fsockPost($encoded_data)
 	{
 
-        if ($this->use_ssl) {
-            $uri = 'ssl://'.$this->getPaypalHost();
-            $port = '443';
-            $this->post_uri = $uri.'/cgi-bin/webscr';
-        } else {
-            $uri = $this->getPaypalHost(); // no "http://" in call to fsockopen()
-            $port = '80';
-            $this->post_uri = 'http://'.$uri.'/cgi-bin/webscr';
-        }
+        $uri = 'ssl://'.$this->getPaypalHost();
+        $port = '443';
+        $this->post_uri = $uri.'/cgi-bin/webscr';
 
         $fp = fsockopen($uri, $port, $errno, $errstr, $this->timeout);
 

--- a/src/IpnListener.php
+++ b/src/IpnListener.php
@@ -57,6 +57,13 @@ class IpnListener
      */
     public $timeout = 30;
 
+    /**
+     * If true, enabled SSL certification validation when using cURL
+     *
+     * @var boolean
+     */
+    public $verify_ssl = true;
+
 	private $_errors = array();
     private $post_data;
 	private $rawPostData;				// raw data from php://input
@@ -87,9 +94,11 @@ class IpnListener
 
         $ch = curl_init();
 
-		curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
-		curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2);
-		curl_setopt($ch, CURLOPT_CAINFO, dirname(__FILE__) . '/cert/api_cert_chain.crt');
+        if ($this->verify_ssl) {
+            curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
+            curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2);
+    		curl_setopt($ch, CURLOPT_CAINFO, dirname(__FILE__) . '/cert/api_cert_chain.crt');
+        }
         curl_setopt($ch, CURLOPT_URL, $uri);
         curl_setopt($ch, CURLOPT_POST, true);
         curl_setopt($ch, CURLOPT_POSTFIELDS, $encoded_data);


### PR DESCRIPTION
1. PayPal always requires SSL on the validation URL (if you use http then it redirects you to https), so the use_ssl option was pointless.

2. I was always getting this error when using cURL:
```
cURL error: [77] error setting certificate verify locations:
CAfile: /path/to/PHP-PayPal-IPN/cert/api_cert_chain.crt
CApath: none
```
So I added the option verify_ssl which skips the `CURLOPT_SSL_VERIFYPEER` and `CURLOPT_SSL_VERIFYHOST` cURL settings and allowed it to work for me.
A better fix would be to figure out why that fails, but this workaround makes it at least work for now.
