### PR TITLE
Mod to getTextReport() and various cleaning up

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 PHP-PayPal-IPN
 ==============
 
-**WARNING:** Version 2.5.1+ has a different namespace! It is now `wadeshuler\paypalipn`!
+**WARNING:** Version 2.5.1+ has a different namespace! It is now `WadeShuler\PhpPaypalIpn`!
 
 Forked from: https://github.com/Quixotix/PHP-PayPal-IPN/
 
-Forked from the great Quixotix PayPal IPN script, which is no longer maintained. From now on, you should use this repo instead, as I have adddressed it's issues and brought it back to life.
+Forked from the great Quixotix PayPal IPN script, which is no longer maintained. From now on, you should use this repo instead, as I have adddressed its issues and brought it back to life.
 
 This fork fixes the known issues with the original repo, as well as updates the code according to PayPal's documentation, and today's standards.
 
@@ -45,7 +45,7 @@ composer.json
     }
 
 
-    use wadeshuler\paypalipn\IpnListener;
+    use WadeShuler\PhpPaypalIpn\IpnListener;
     $listener = new IpnListener();
 
     // default options
@@ -104,7 +104,7 @@ below. For a more thoroughly documented example, take a look at the
 
     require_once('vendor/autoload.php');
 
-    $listener = new \wadeshuler\paypalipn\IpnListener();
+    $listener = new WadeShuler\PhpPaypalIpn\IpnListener();
     $listener->use_sandbox = true;
 
     if ($verified = $listener->processIpn())

--- a/example/ipn.php
+++ b/example/ipn.php
@@ -17,7 +17,9 @@
  */
 
 // include the IPNListener Class
-require_once( dirname(dirname(__FILE__)) . DIRECTORY_SEPARATOR . 'src' . DIRECTORY_SEPARATOR . 'IPNListener.php');
+require_once( dirname(dirname(__FILE__)) . DIRECTORY_SEPARATOR . 'src' . DIRECTORY_SEPARATOR . 'IpnListener.php');
+
+use WadeShuler\PhpPaypalIpn\IpnListener;
 
 $listener = new IpnListener();      // NOTICE new upper-casing of the class name
 $listener->use_sandbox = true;      // Only needed for testing (sandbox), else omit or set false
@@ -36,12 +38,16 @@ if ($verified = $listener->processIpn())
     */
     $transactionRawData = $listener->getRawPostData();      // raw data from PHP input stream
     $transactionData = $listener->getPostData();            // POST data array
+    
+//	NOTICE webserver must be able to write to ipn_success.log
     file_put_contents('ipn_success.log', print_r($transactionData, true) . PHP_EOL, LOCK_EX | FILE_APPEND);
 
 } else {
 
     // Invalid IPN
     $errors = $listener->getErrors();
+
+//	NOTICE webserver must be able to write to ipn_errors.log
     file_put_contents('ipn_errors.log', print_r($errors, true) . PHP_EOL, LOCK_EX | FILE_APPEND);
 
 }

--- a/src/IpnListener.php
+++ b/src/IpnListener.php
@@ -1,9 +1,4 @@
 <?php
-
-namespace wadeshuler\paypalipn;
-
-use Exception;
-
 /**
  *  PayPal IPN Listener
  *
@@ -22,6 +17,11 @@ use Exception;
  *  @license    http://choosealicense.com/licenses/gpl-2.0/
  *  @version    2.5.0
  */
+
+namespace WadeShuler\PhpPaypalIpn;
+
+use Exception;
+
 class IpnListener
 {
 
@@ -264,7 +264,9 @@ class IpnListener
         $r .= "\n";
 
         foreach ($this->post_data as $key => $value) {
-            $r .= str_pad($key, 25)."$value\n";
+            $param = explode("=", $value);
+            $r .= str_pad(urldecode($param[0]), 25).urldecode($param[1])."\n";
+//            $r .= str_pad($key, 25)."$value\n";
         }
         $r .= "\n\n";
 


### PR DESCRIPTION
Hi Wade,
I decided to make my suggestions official, so here's a pull request for your review.  I noticed when testing that the output from `getTextReport()` had changed from older versions:

The old, human-friendly output:

    VERIFIED
    --------------------------------------------------------------------------------
    transaction_subject      Web Hosting Fee - fooblah.com
    payment_date             11:49:20 Sep 30, 2015 PDT
    txn_type                 subscr_payment
    subscr_id                I-EVT25F7PBT2Y
    last_name                Sample
    residence_country        US
    item_name                Web Hosting Fee - fooblah.com

The new, raw output:

    VERIFIED
    --------------------------------------------------------------------------------
    0                        payer_id=MQGODH32FVGTSJ
    1                        btn_id=207131084
    2                        ipn_track_id=9bef091f76e31
    3                        charset=windows-1252
    4                        verify_sign=AiPC9BjkCyDFQXbSkoZcg3B0ApacA3Xxep8StVdmX2l9qZ4uvdufGuia
    5                        item_name=Web+Hosting+Fee+-+fooblah.com

I traced this change to `processIpn()` where, according to your comment, you switched from using `$_POST` to raw post data, for serialization reasons.  Makes sense, but I prefer `getTextReport()` to produce human-friendly output, so I modified it to urldecode the post array to key/value pairs.

The rest of the changes I made were corrections to namespace names and capitalization in both `README.md` and `example/ipn.php`.

Thanks again for resurrecting this project, and I'm willing to help maintain it if you need a hand.