### PR TITLE
Add option to use curl SSL version 6 (tls 1.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 PHP-PayPal-IPN
 ==============
 
-**WARNING:** Version 2.5.1+ has a different namespace! It is now `wadeshuler\paypalipn`!
+Forked from: https://github.com/WadeShuler/PHP-PayPal-IPN
 
 Forked from: https://github.com/Quixotix/PHP-PayPal-IPN/
 
@@ -12,16 +12,6 @@ This fork fixes the known issues with the original repo, as well as updates the 
 **NOTICE: The SSLv3 issue is fixed!**
 
 **This has been fixed and works out of the box, the old `Quixotix` repo no longer works!**
-
-**PLEASE NOTE: I am still in the works of cleaning this package up. These docs still have remnants of the original repo, so please bare with me.** I am not trying to remove his name, and I give Quixotix full credit for his original work. His repo just hasn't been updated since 2012, and it's now 2015 and it isn't maintained anymore. If there is anything I need to do, or reword, to ensure he is appropriately credited just let me know.
-
-@TODO Recode to follow best practices (camelCase, etc).
-
-@TODO Finish updating Readme and Documentation.
-
-@TODO Add security to verify payment status is completed and owner's PayPal email address.
-
-@TODO Update examples
 
 **Requires:** PHP >= 5.3
 
@@ -52,8 +42,9 @@ composer.json
     $listener->use_sandbox = true;
     $listener->use_curl = true;
     $listener->follow_location = false;
-    $listener->timeout = 30;
+    $listener->timeout = 30; 
     $listener->verify_ssl = true;
+    $listener->use_tls = false; //Curl specify using SSL 6 (TLS 1.2)
 
     if ($verified = $listener->processIpn())
     {

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "Shane-Lessard/php-paypal-ipn",
     "description": "Forked, Fixed, and Updated on 2-3-2015. A class to listen for and handle Instant Payment Notifications (IPN) from the PayPal server.",
-    "homepage": "https://github.com/Shane-Lessard/PHP-PayPal-IPN",
+    "homepage": "https://github.com/shane-lessard/php-paypal-ipn",
     "keywords": ["paypal", "ipn", "php"],
     "license": "GPL-2.0+",
     "version": "2.5.2",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "Shane-Lessard/php-paypal-ipn",
+    "name": "shane-lessard/php-paypal-ipn",
     "description": "Forked, Fixed, and Updated on 2-3-2015. A class to listen for and handle Instant Payment Notifications (IPN) from the PayPal server.",
     "homepage": "https://github.com/shane-lessard/php-paypal-ipn",
     "keywords": ["paypal", "ipn", "php"],

--- a/composer.json
+++ b/composer.json
@@ -1,11 +1,15 @@
 {
-    "name": "wadeshuler/php-paypal-ipn",
+    "name": "Shane-Lessard/php-paypal-ipn",
     "description": "Forked, Fixed, and Updated on 2-3-2015. A class to listen for and handle Instant Payment Notifications (IPN) from the PayPal server.",
-    "homepage": "https://github.com/WadeShuler/PHP-PayPal-IPN",
+    "homepage": "https://github.com/Shane-Lessard/PHP-PayPal-IPN",
     "keywords": ["paypal", "ipn", "php"],
     "license": "GPL-2.0+",
     "version": "2.5.2",
     "authors": [
+        {
+          "name": "Shane Lessard",
+          "homepage": "https://github.com/Shane-Lessard"
+        },
         {
             "name": "Wade Shuler",
             "homepage": "https://github.com/WadeShuler/"
@@ -17,15 +21,15 @@
         }
     ],
     "support": {
-        "issues": "https://github.com/WadeShuler/PHP-PayPal-IPN/issues",
-        "source": "https://github.com/WadeShuler/PHP-PayPal-IPN/"
+        "issues": "https://github.com/Shane-Lessard/PHP-PayPal-IPN/issues",
+        "source": "https://github.com/Shane-Lessard/PHP-PayPal-IPN/"
     },
     "require": {
         "php": ">=5.3.0"
     },
     "autoload": {
         "psr-4": {
-            "wadeshuler\\paypalipn\\": "src/"
+            "Shane-Lessard\\paypalipn\\": "src/"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "shane-lessard/php-paypal-ipn",
+    "name": "shanelessard/php-paypal-ipn",
     "description": "Forked, Fixed, and Updated on 2-3-2015. A class to listen for and handle Instant Payment Notifications (IPN) from the PayPal server.",
     "homepage": "https://github.com/shane-lessard/php-paypal-ipn",
     "keywords": ["paypal", "ipn", "php"],
@@ -29,7 +29,7 @@
     },
     "autoload": {
         "psr-4": {
-            "Shane-Lessard\\paypalipn\\": "src/"
+            "shanelessard\\paypalipn\\": "src/"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "homepage": "https://github.com/shane-lessard/php-paypal-ipn",
     "keywords": ["paypal", "ipn", "php"],
     "license": "GPL-2.0+",
-    "version": "2.5.2",
+    "version": "2.6.0",
     "authors": [
         {
           "name": "Shane Lessard",

--- a/src/IpnListener.php
+++ b/src/IpnListener.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace wadeshuler\paypalipn;
+namespace shanelessard\paypalipn;
 
 use Exception;
 

--- a/src/IpnListener.php
+++ b/src/IpnListener.php
@@ -64,6 +64,13 @@ class IpnListener
      */
     public $verify_ssl = true;
 
+    /**
+     * If true, declase curl SSL version 6 (tls 1.2)
+     * 
+     * @var bool
+     */
+    public $use_tls = false;
+
     private $_errors = array();
     private $post_data;
     private $rawPostData;				// raw data from php://input
@@ -97,6 +104,10 @@ class IpnListener
             curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
             curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2);
             curl_setopt($ch, CURLOPT_CAINFO, dirname(dirname(__FILE__)) . '/cert/api_cert_chain.crt');
+        }
+
+        if ($this->use_tls){
+            curl_setopt($ch, CURLOPT_SSLVERSION, 6);
         }
 
         curl_setopt($ch, CURLOPT_URL, $uri);


### PR DESCRIPTION
Possible solution to <a href='https://github.com/WadeShuler/PHP-PayPal-IPN/issues/18'>Issue 18</a>. Solved similar error for me. 