### PR TITLE
Fix a PHP warn and add useful data to exception

### DIFF
--- a/src/IpnListener.php
+++ b/src/IpnListener.php
@@ -369,7 +369,7 @@ class IpnListener
         // require POST requests
         if ($_SERVER['REQUEST_METHOD'] && $_SERVER['REQUEST_METHOD'] != 'POST') {
             header('Allow: POST', true, 405);
-            throw new Exception("Invalid HTTP request method.");
+            throw new Exception("Invalid HTTP request method (" . $_SERVER['REQUEST_METHOD'] . ") from " . $_SERVER['REMOTE_ADDR'] . " - " . $_SERVER['HTTP_USER_AGENT'] . ")");
         }
     }
 

--- a/src/IpnListener.php
+++ b/src/IpnListener.php
@@ -263,8 +263,10 @@ class IpnListener
         for ($i=0; $i<80; $i++) { $r .= '-'; }
         $r .= "\n";
 
-        foreach ($this->post_data as $key => $value) {
-            $r .= str_pad($key, 25)."$value\n";
+        if (!empty($this->post_data)) {
+            foreach ($this->post_data as $key => $value) {
+                $r .= str_pad($key, 25)."$value\n";
+            }
         }
         $r .= "\n\n";
 


### PR DESCRIPTION
Check post_data before iterating over it, and add data about the request to the non-POST exception.