### PR TITLE
Remove Magic Quotes support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ composer.json
         }
     }
 
+PHP implementation:
 
     use wadeshuler\paypalipn\IpnListener;
     $listener = new IpnListener();

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ This fork fixes the known issues with the original repo, as well as updates the 
 
 @TODO Update examples
 
-**Requires:** PHP >= 5.3
+**Requires:** PHP >= 5.4
 
-A PayPal Instant Payment Notification (IPN) class for PHP >= 5.3 (if you aren't on at least 5.3, then I can't help you! I will not support dead versions!)
+A PayPal Instant Payment Notification (IPN) class for PHP >= 5.4 (if you aren't on at least 5.4, then I can't help you! I will not support dead versions!)
 
 Use the `IpnListener` class in your PHP IPN script to handle the encoding of POST data, post back to PayPal, and parsing of the response from PayPal.
 

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "source": "https://github.com/WadeShuler/PHP-PayPal-IPN/"
     },
     "require": {
-        "php": ">=5.3.0"
+        "php": ">=5.4.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/IpnListener.php
+++ b/src/IpnListener.php
@@ -323,12 +323,7 @@ class IpnListener
             $req = 'cmd=_notify-validate';
 
             foreach ($myPost as $key => $value) {
-                if (function_exists('get_magic_quotes_gpc') && get_magic_quotes_gpc() == 1) {
-                    $value = urlencode(stripslashes($value));
-                } else {
-                    $value = urlencode($value);
-                }
-                $req .= "&$key=$value";
+                $req .= "&{$key}=" . urlencode($value);
             }
 
             if ($this->use_curl) {


### PR DESCRIPTION
1. Removed support for Magic Quotes due to errors in PHP 7.
2. Updated docs to reflect this.
3. Clarified the README example.